### PR TITLE
doc: Added option reference for `starknet-compile`.

### DIFF
--- a/components/StarkNet/modules/develop/nav.adoc
+++ b/components/StarkNet/modules/develop/nav.adoc
@@ -10,8 +10,6 @@
 ** Hashing
 *** xref:Hashing/hash-functions.adoc[Hash functions]
 
-** xref:CLI/commands.adoc[StarkNet CLI reference]
-
 ** Contracts
 *** xref:Contracts/contract-abi.adoc[Contract ABI]
 *** xref:Contracts/contract-address.adoc[Contract address]
@@ -35,3 +33,6 @@
 
 ** State
 *** xref:State/starknet-state.adoc[StarkNet state]
+
+** xref:CLI/commands.adoc[StarkNet CLI reference]
+** xref:CLI/starknet-compiler-options.adoc[StarkNet compiler reference]

--- a/components/StarkNet/modules/develop/pages/CLI/starknet-compiler-options.adoc
+++ b/components/StarkNet/modules/develop/pages/CLI/starknet-compiler-options.adoc
@@ -22,6 +22,26 @@ starknet-compile [-h] [--abi _ABI_] [--disable_hint_validation]
                       file [__file__ ...]
 ----
 
+== Example
+
+The following example compiles the file `contract.cairo`. It generates two files:
+
+contract_compiled.json:: The contract class. This file contains the bytecode and all other information necessary to execute a contract. For information on contract classes, see xref:Contracts/contract-classes.adoc[].
++
+Declare this contract class on StarkNet.*
+//* For information on declaring a contract class, see xref:CLI/commands.adoc#starknet_declare[].
+contract_abi.json:: The contract's ABI.
+
+[source,shell]
+----
+starknet-compile contract.cairo \
+    --output contract_compiled.json \
+    --abi contract_abi.json
+----
+
+
+
+
 == Description
 
 A tool to compile StarkNet contracts.

--- a/components/StarkNet/modules/develop/pages/CLI/starknet-compiler-options.adoc
+++ b/components/StarkNet/modules/develop/pages/CLI/starknet-compiler-options.adoc
@@ -1,0 +1,93 @@
+[id="starknet-compiler-options"]
+= Starknet compiler options reference
+
+When the StarkNet compiler is installed, you can view this command-line help in a terminal by entering the following command:
+
+[source,bash]
+----
+starknet-compile --help
+----
+
+== Usage
+
+[source,bash,subs="+quotes,+macros"]
+----
+starknet-compile [-h] [--abi _ABI_] [--disable_hint_validation]
+                      [--account_contract] [--dont_filter_identifiers] [-v]
+                      [--prime __PRIME__] [--cairo_path CAIRO_PATH]
+                      [--preprocess] [--output __OUTPUT__] [--no_debug_info]
+                      [--debug_info_with_source]
+                      [--cairo_dependencies __CAIRO_DEPENDENCIES__]
+                      [--no_opt_unused_functions]
+                      file [__file__ ...]
+----
+
+== Description
+
+A tool to compile StarkNet contracts.
+
+== Positional arguments
+
+
+=== file
+
+File names.
+
+== Optional arguments
+
+
+=== `-h`, `--help`
+
+Show this help message and exit.
+
+=== `--abi _ABI_`
+
+Output the contract's ABI.
+
+=== `--disable_hint_validation`
+
+Disable the hint validation.
+
+=== `--account_contract`
+
+Compile as account contract.
+
+=== `--dont_filter_identifiers`
+
+Disable the filter-identifiers-optimization.If True, all the identifiers will be kept, instead of just the ones mentioned in hints or 'with_attr' statements.
+
+=== `-v`, `--version`
+
+show program's version number and exit
+
+=== `--prime _PRIME_`
+
+The size of the finite field.
+
+=== `--cairo_path _CAIRO_PATH_`
+
+A list of directories, separated by ":" to resolve import paths. The full list will consist of directories defined by this argument, followed by the environment variable CAIRO_PATH, the working directory and the standard library path.
+
+=== `--preprocess`
+
+Stop after the preprocessor step and output the preprocessed program.
+
+=== `--output _OUTPUT_`
+
+The output file name (default: `stdout`).
+
+=== `--no_debug_info`
+
+Don't include debug information in the compiled file.
+
+=== `--debug_info_with_source`
+
+Include debug information with a copy of the source code.
+
+=== `--cairo_dependencies _CAIRO_DEPENDENCIES_`
+
+Output a list of the Cairo source files used during the compilation as a CMake file.
+
+=== `--no_opt_unused_functions`
+
+Disables unused function optimization.

--- a/components/StarkNet/modules/develop/pages/CLI/starknet-compiler-options.adoc
+++ b/components/StarkNet/modules/develop/pages/CLI/starknet-compiler-options.adoc
@@ -26,10 +26,8 @@ starknet-compile [-h] [--abi _ABI_] [--disable_hint_validation]
 
 The following example compiles the file `contract.cairo`. It generates two files:
 
+[horizontal]
 contract_compiled.json:: The contract class. This file contains the bytecode and all other information necessary to execute a contract. For information on contract classes, see xref:Contracts/contract-classes.adoc[].
-+
-Declare this contract class on StarkNet.*
-//* For information on declaring a contract class, see xref:CLI/commands.adoc#starknet_declare[].
 contract_abi.json:: The contract's ABI.
 
 [source,shell]


### PR DESCRIPTION
### Description of the Changes

The StarkNet compiler will be updated soon for Cairo 1.0/regenesis, so in order not to spend much time on something that will be obsolete within 3-6 months, this task is essentially to add the command line help (`starknet-compile --help`) to the docs.

### Preview

https://starknet-community-libs.github.io/starknet-docs/pr-83/documentation/develop/CLI/starknet-compiler-options

### Check List

- [x] Changes have been done against dev branch, and PR does not conflict
- [x] PR title follows the convention: `<feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-community-libs/starknet-docs/83)
<!-- Reviewable:end -->
