### PR TITLE
fix: typo in Block Explorers--Viewblock should be ViewBlock

### DIFF
--- a/components/StarkNet/modules/ROOT/pages/Ecosystem/con_block_explorers.adoc
+++ b/components/StarkNet/modules/ROOT/pages/Ecosystem/con_block_explorers.adoc
@@ -10,6 +10,6 @@ The following block explorers provide information on StarkNet.
 | Block explorer name | URL
 
 |Starkscan | link:https://starkscan.co[https://starkscan.co^]
-|Viewblock | link:https://v2.viewblock.io/starknet[https://v2.viewblock.io/starknet^]
+|ViewBlock | link:https://v2.viewblock.io/starknet[https://v2.viewblock.io/starknet^]
 |Voyager | link:https://voyager.online[https://voyager.online^]
 |===


### PR DESCRIPTION
### Description of the Changes

Fixing a typo

### Check List

- [x] Changes have been done against dev branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-community-libs/starknet-docs/87)
<!-- Reviewable:end -->
