### PR TITLE
docs: Added operational info

### DIFF
--- a/components/StarkNet/modules/ROOT/nav.adoc
+++ b/components/StarkNet/modules/ROOT/nav.adoc
@@ -2,3 +2,4 @@ About StarkNet
 
 * xref:index.adoc[]
 * xref:Ecosystem/ref_block_explorers.adoc[]
+* xref:Ecosystem/ref_operational_info.adoc[]

--- a/components/StarkNet/modules/ROOT/pages/Ecosystem/ref_operational_info.adoc
+++ b/components/StarkNet/modules/ROOT/pages/Ecosystem/ref_operational_info.adoc
@@ -5,15 +5,13 @@
 
 The StarkNet core contract:: link:https://etherscan.io/address/0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4[`0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4`^]
 Verifier address::  link:https://etherscan.io/address/0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60[`0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60`^]
-// ??? This URL does not work. What is the correct URL???
-Sequencer URL:: https://alpha-mainnet.starknet.io[https://alpha-mainnet.starknet.io^]
+Sequencer base URL for API routing:: \https://alpha-mainnet.starknet.io
 
 == StarkNet Alpha version 4 on Goerli
 
 The StarkNet core contract:: link:https://goerli.etherscan.io/address/0xde29d060D45901Fb19ED6C6e959EB22d8626708e[`0xde29d060D45901Fb19ED6C6e959EB22d8626708e`^]
 Verifier address::  link:https://goerli.etherscan.io/address/0xAB43bA48c9edF4C2C4bB01237348D1D7B28ef168[`0xAB43bA48c9edF4C2C4bB01237348D1D7B28ef168`^]
-// ??? This URL does not work. What is the correct URL???
-Sequencer URL:: https://alpha4.starknet.io[https://alpha4.starknet.io^]
+Sequencer base URL for API routing:: \https://alpha4.starknet.io
 
 == Bridged Tokens
 

--- a/components/StarkNet/modules/ROOT/pages/Ecosystem/ref_operational_info.adoc
+++ b/components/StarkNet/modules/ROOT/pages/Ecosystem/ref_operational_info.adoc
@@ -7,11 +7,17 @@ The StarkNet core contract:: link:https://etherscan.io/address/0xc662c410C0ECf74
 Verifier address::  link:https://etherscan.io/address/0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60[`0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60`^]
 Sequencer base URL for API routing:: \https://alpha-mainnet.starknet.io
 
-== StarkNet Alpha version 4 on Goerli
+== StarkNet Alpha version 4 on Goerli testnet 1
 
 The StarkNet core contract:: link:https://goerli.etherscan.io/address/0xde29d060D45901Fb19ED6C6e959EB22d8626708e[`0xde29d060D45901Fb19ED6C6e959EB22d8626708e`^]
 Verifier address::  link:https://goerli.etherscan.io/address/0xAB43bA48c9edF4C2C4bB01237348D1D7B28ef168[`0xAB43bA48c9edF4C2C4bB01237348D1D7B28ef168`^]
 Sequencer base URL for API routing:: \https://alpha4.starknet.io
+
+== StarkNet Alpha version 4 on Goerli testnet 2
+
+The StarkNet core contract:: link:https://goerli.etherscan.io/address/0xa4eD3aD27c294565cB0DCc993BDdCC75432D498c[`0xa4eD3aD27c294565cB0DCc993BDdCC75432D498c`^]
+Verifier address::  link:https://goerli.etherscan.io/address/0xAB43bA48c9edF4C2C4bB01237348D1D7B28ef168[`0xAB43bA48c9edF4C2C4bB01237348D1D7B28ef168`^]
+Sequencer base URL for API routing:: \https://alpha4-2.starknet.io
 
 == Bridged Tokens
 
@@ -35,4 +41,4 @@ l2_bridge_address:: address of the L2 bridge contract
 
 The field element type in StarkNet is based on the field in the underlying Cairo VM. In other words, a value stem:[$$x$$] of a field element type is an integer in the range of stem:[$$0≤x<P$$].
 
-stem:[$$P$$] is currently defined as stem:[$$2^251 + 17*2^192 + 1$$]
+stem:[$$P$$] is currently defined as stem:[$$2^{251} + 17*2^{192} + 1$$]

--- a/components/StarkNet/modules/ROOT/pages/Ecosystem/ref_operational_info.adoc
+++ b/components/StarkNet/modules/ROOT/pages/Ecosystem/ref_operational_info.adoc
@@ -1,0 +1,21 @@
+[id="operational_info"]
+= Operation info
+
+==  StarkNet Alpha on Mainnet
+
+The StarkNet core contract:: link:https://etherscan.io/address/0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4[`0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4`]
+Verifier address::  link:https://etherscan.io/address/0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60[`0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60`]
+
+Sequencer URL:: https://alpha-mainnet.starknet.io
+
+== StarkNet Alpha version 4 on Goerli
+
+The StarkNet core contract:: `0xde29d060D45901Fb19ED6C6e959EB22d8626708e`
+Sequencer URL:: https://alpha4.starknet.io
+Bridge L1 address::
+Bridge L2 address::
+P value::
+L1 verifier::
+ETH address on L2::
+
+Link to the github repos

--- a/components/StarkNet/modules/ROOT/pages/Ecosystem/ref_operational_info.adoc
+++ b/components/StarkNet/modules/ROOT/pages/Ecosystem/ref_operational_info.adoc
@@ -17,23 +17,24 @@ Sequencer URL:: https://alpha4.starknet.io[https://alpha4.starknet.io^]
 
 == Bridged Tokens
 
-The `starknet-addresses` repository contains the following `.json` files:
+The tokens that are currently bridged to StarkNet are listed in the following `.json` files:
 
-* link:https://github.com/starknet-community-libs/starknet-addresses/blob/master/bridged_tokens/mainnet.json[`mainnet.json`^]
-* https://github.com/starknet-community-libs/starknet-addresses/blob/master/bridged_tokens/goerli.json[`goerli.json`^]
+link:https://github.com/starknet-community-libs/starknet-addresses/blob/master/bridged_tokens/mainnet.json[`mainnet.json`^]:: The addresses of the tokens currently bridged to StarkNet Mainnet.
+https://github.com/starknet-community-libs/starknet-addresses/blob/master/bridged_tokens/goerli.json[`goerli.json`^]:: The addresses of the tokens currently bridged to StarkNet testnet.
 
-Each file lists the addresses of the tokens currently bridged to StarkNet. Each token has the following parameters:
 
-Name:: name of the token
+Each token has the following parameters:
+
+Name:: token name
 Symbol:: token symbol
-Decimals:: number of decimals used to get the user representation
+Decimals:: number of decimal places used to get the user representation
 l1_token_address:: address of the L1 ERC-20 contract
 l2_token_address:: address of the L2 ERC-20 contract
 l1_bridge_address:: address of the L1 bridge contract
 l2_bridge_address:: address of the L2 bridge contract
 
-////
+== `P` value
 
-??? Is this the information for p-value that you feel should be on this page? ???
-The field element type in StarkNet is based on the field in the underlying Cairo VM. In other words, a value `x` of a field element type is an integer in the range of `+0≤x<P+`. `+P+` is currently defined as `2^251^+(17*2^192^)+1`
-////
+The field element type in StarkNet is based on the field in the underlying Cairo VM. In other words, a value stem:[$$x$$] of a field element type is an integer in the range of stem:[$$0≤x<P$$].
+
+stem:[$$P$$] is currently defined as stem:[$$2^251 + 17*2^192 + 1$$]

--- a/components/StarkNet/modules/ROOT/pages/Ecosystem/ref_operational_info.adoc
+++ b/components/StarkNet/modules/ROOT/pages/Ecosystem/ref_operational_info.adoc
@@ -1,21 +1,39 @@
 [id="operational_info"]
-= Operation info
+= Operational info
 
 ==  StarkNet Alpha on Mainnet
 
-The StarkNet core contract:: link:https://etherscan.io/address/0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4[`0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4`]
-Verifier address::  link:https://etherscan.io/address/0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60[`0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60`]
-
-Sequencer URL:: https://alpha-mainnet.starknet.io
+The StarkNet core contract:: link:https://etherscan.io/address/0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4[`0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4`^]
+Verifier address::  link:https://etherscan.io/address/0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60[`0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60`^]
+// ??? This URL does not work. What is the correct URL???
+Sequencer URL:: https://alpha-mainnet.starknet.io[https://alpha-mainnet.starknet.io^]
 
 == StarkNet Alpha version 4 on Goerli
 
-The StarkNet core contract:: `0xde29d060D45901Fb19ED6C6e959EB22d8626708e`
-Sequencer URL:: https://alpha4.starknet.io
-Bridge L1 address::
-Bridge L2 address::
-P value::
-L1 verifier::
-ETH address on L2::
+The StarkNet core contract:: link:https://goerli.etherscan.io/address/0xde29d060D45901Fb19ED6C6e959EB22d8626708e[`0xde29d060D45901Fb19ED6C6e959EB22d8626708e`^]
+Verifier address::  link:https://goerli.etherscan.io/address/0xAB43bA48c9edF4C2C4bB01237348D1D7B28ef168[`0xAB43bA48c9edF4C2C4bB01237348D1D7B28ef168`^]
+// ??? This URL does not work. What is the correct URL???
+Sequencer URL:: https://alpha4.starknet.io[https://alpha4.starknet.io^]
 
-Link to the github repos
+== Bridged Tokens
+
+The `starknet-addresses` repository contains the following `.json` files:
+
+* link:https://github.com/starknet-community-libs/starknet-addresses/blob/master/bridged_tokens/mainnet.json[`mainnet.json`^]
+* https://github.com/starknet-community-libs/starknet-addresses/blob/master/bridged_tokens/goerli.json[`goerli.json`^]
+
+Each file lists the addresses of the tokens currently bridged to StarkNet. Each token has the following parameters:
+
+Name:: name of the token
+Symbol:: token symbol
+Decimals:: number of decimals used to get the user representation
+l1_token_address:: address of the L1 ERC-20 contract
+l2_token_address:: address of the L2 ERC-20 contract
+l1_bridge_address:: address of the L1 bridge contract
+l2_bridge_address:: address of the L2 bridge contract
+
+////
+
+??? Is this the information for p-value that you feel should be on this page? ???
+The field element type in StarkNet is based on the field in the underlying Cairo VM. In other words, a value `x` of a field element type is an integer in the range of `+0≤x<P+`. `+P+` is currently defined as `2^251^+(17*2^192^)+1`
+////


### PR DESCRIPTION
### Description of the Changes

Added StarkNet operational info.

### Preview URLs

https://starknet-community-libs.github.io/starknet-docs/pr-91/documentation/Ecosystem/ref_operational_info/

### Check List

- [ ] Changes have been done against dev branch, and PR does not conflict
- [x] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-community-libs/starknet-docs/91)
<!-- Reviewable:end -->
