### PR TITLE
[Fix] Added permutation of token-bridge URL to redirect file

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -105,6 +105,12 @@ RewriteCond %{QUERY_STRING} ^$
 RewriteRule ^docs/L1\-L2\ Communication/token\-bridge/index\.html$ /documentation/develop/L1-L2_Communication/token-bridge? [R=301,L]
 
 RewriteCond %{QUERY_STRING} ^$
+RewriteRule ^docs/L1\<\>L2\ Communication/token\-bridge$ /documentation/develop/L1-L2_Communication/token-bridge? [R=301,L]
+
+RewriteCond %{QUERY_STRING} ^$
+RewriteRule ^docs/L1\<\>L2\ Communication/token\-bridge/index\.html$ /documentation/develop/L1-L2_Communication/token-bridge? [R=301,L]
+
+RewriteCond %{QUERY_STRING} ^$
 RewriteRule ^docs/State/starknet\-state$ /documentation/develop/State/starknet-state? [R=301,L]
 
 RewriteCond %{QUERY_STRING} ^$


### PR DESCRIPTION
### Description of the Changes

﻿There was some change to the syntax of the URL over time (before the move to Antora). The Google result uses this
docs/L1<b><></b>L2 Communication/token-bridge, while the one that was in the redirect had this:
docs/L1-L2 Communication/token-bridge
Now it includes both.

### Check List

- [ ] Changes have been done against dev branch, and PR does not conflict
- [ ] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-community-libs/starknet-docs/95)
<!-- Reviewable:end -->
