### PR TITLE
chore: Updating release instructions to use `git rebase` instead of `git merge`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -48,7 +48,7 @@ After writing or editing content, to preview your changes:
 
 . Build the content by running the `build_local_site.sh` build script:
 +
-[source,shell]
+[source,bash]
 ----
 $ ./build_local_site
 ----
@@ -59,14 +59,14 @@ This command generates the website in the directory `public_html`.
 * Open the start page: `<repo_root>/public_html/index.html`.
 * Run the xref:http_server[http server] packaged with Antora:
 +
-[source,shell]
+[source,bash]
 ----
 $ http-server public_html -c-1
 ----
 +
 The server runs, and gives you one or more local URLs that you can use to view the website. For example:
 +
-[source,shell,subs="+quotes,+macros"]
+[source,bash,subs="+quotes,+macros"]
 ----
 Starting up http-server, serving *public_html*
 
@@ -97,31 +97,40 @@ Previously, this repo used Pre-release tags in addition to Release tags. This fu
 
 === Procedure
 
-. Merge `dev` into `master` on your local starknet-docs repo:
+. Checkout the `master` branch.
+. Fetch the latest changes from the main repo, `origin`. If your origin is a fork of the main repo, update this command appropriately:
 +
-[source,shell]
+[source,bash]
 ----
-starknet-docs (master) $ git merge dev
+starknet-docs (master) $ git fetch origin
+----
+//. Merge `dev` into `master` on your local starknet-docs repo:
+. Rebase `dev` into `master` on your local starknet-docs repo:
+// [source,bash]
+//----
+//starknet-docs (master) $ git merge dev
+//----
++
+[source,bash]
+----
+starknet-docs (master) $ git rebase origin/dev
 ----
 +
 Your local version of `master` now includes all the changes from `dev`.
 . Push the local version of `master` to Github:
 +
-[source,shell]
+[source,bash]
 ----
-starknet-docs (master) $ git push origin master
+starknet-docs (master) $ git push -f origin master
 ----
 +
 Github increments the version numbers in `package.json` and `package-lock.json`, and updates `CHANGELOG.md` with the descriptions of each PR that was just merged into `master`.
 . Update your local `dev` branch from the remote `master` branch:
 +
-[source,shell]
+[source,bash]
 ----
 starknet-docs (master) $ git checkout dev
 starknet-docs (dev) $ git fetch origin
 starknet-docs (dev) $ git rebase origin/master
 ----
-
-
-
 


### PR DESCRIPTION
### Description of the Changes

Updating release instructions to use `git rebase` instead of `git merge`

### PR Preview URL

After you push a commit to this PR, a preview is built and a URL to the root of the preview appears in the comment feed.

Paste here the specific URL(s) of the content that this PR addresses.

### Check List

- [ ] Changes have been done against dev branch, and PR does not conflict
- [ ] PR title follows the convention: `<docs/feat/fix/chore>(optional scope): <description>`, e.g: `fix: minor typos in code`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starknet-community-libs/starknet-docs/103)
<!-- Reviewable:end -->
